### PR TITLE
Fix dumping in_port(0)

### DIFF
--- a/pretty_dump.py
+++ b/pretty_dump.py
@@ -315,7 +315,10 @@ class FlowTableEntry(Flow):
         self._ignore.append('misc_parameters.source_port')
         port = self['misc_parameters.source_port']
         if not port:
-            return ''
+            if self.group['misc_parameters.source_port']:
+                port = '0'
+            else:
+                return ''
         return 'in_port(%s)' % self.port_name(port)
 
     @property


### PR DESCRIPTION
If the source_port is expected in the group, but isn't present in the FTE,
then it is 0 and was filtered out of the dump erroneously.

Signed-off-by: Gavi Teitz <gavi@mellanox.com>